### PR TITLE
hmac py3 compatibility

### DIFF
--- a/schoolyourself/schoolyourself.py
+++ b/schoolyourself/schoolyourself.py
@@ -11,6 +11,8 @@ from xblock.core import XBlock
 from xblock.fields import Scope, String
 from xblock.fragment import Fragment
 
+from .utils import convert_to_bytes
+
 
 class SchoolYourselfXBlock(XBlock):
     """Common functionality for the School Yourself XBlocks.
@@ -157,8 +159,10 @@ class SchoolYourselfXBlock(XBlock):
       if user_id:
         url_params["partner_user_id"] = user_id
         if shared_key:
-          url_params["partner_signature"] = hmac.new(str(shared_key),
-                                                     user_id).hexdigest()
+            # Verify the signature.
+            shared_key = convert_to_bytes(shared_key)
+            user_id = convert_to_bytes(user_id)
+            url_params["partner_signature"] = hmac.new(shared_key, user_id).hexdigest()
 
       return url_params
 

--- a/schoolyourself/utils.py
+++ b/schoolyourself/utils.py
@@ -1,0 +1,15 @@
+"""Utility file to contain various functions be to used across multiple files."""
+
+from __future__ import absolute_import
+
+from six import text_type
+
+
+def convert_to_bytes(value):
+    """
+    Utility method to convert & return type str to type bytes,
+    otherwise return the original value.
+    """
+    if isinstance(value, text_type):
+        return value.encode('utf-8')
+    return value


### PR DESCRIPTION
### [PROD-1108](https://openedx.atlassian.net/browse/PROD-1108)

### Description
This PR is updating the codebase to be `hmac` compatible in python3. [hmac](https://docs.python.org/3/library/hmac.html) python3 upgrade has various changes. In our codebase, the usage of the following two methods needed an alteration :
1. new (hmac.new(key, msg=None, digestmod='')
2. update (HMAC.update(msg))

In the new method, the `key` argument has to be bytes/bytearray, but the current codebase is passing `str`, which resulted in failure([Reference](https://github.com/python/cpython/blob/3.5/Lib/hmac.py#L26-L54)). The `msg` argument is a type supposed by `hashlib` which also demands bytes([Link](https://docs.python.org/3/library/hashlib.html#module-hashlib): Read the note `Feeding string objects into update() is not supported, as hashes work on bytes, not on characters. `).

The changes in this PR ensure that the correct type of data is passed to hmac.

### Testing Instructions
The changes should be tested on your local machine by following the steps:
1. Export [this](https://studio.edx.org/export/course-v1:SchoolYourself+AlgebraX+2T2016) course and import in one of your local course.
2. Verify the content isn't accessible on both studio & LMS.
3. Clone this repo in `src` directory(src directory should be a sibling of devstack directory).
4. Fetch and checkout to branch `dsheraz/PROD-1108`
5. Install the local clone in both lms & studio by running `pip install -e /edx/src/schoolyourself-xblock` in lms & studio shell respectively.
6. Once installed, restart LMS & studio. 
7. The content will be accessible in both parts.

**NOTE: The review block currently shows a white screen on opening. When inspected, this [URL](https://schoolyourself.org/review/embed?module=algebra%2Fslope_intro&partner=edx&partner_signature=c2933d22863c34b8b49911696e79250a&partner_user_id=5a8fd31302b6ed7a09a9e2f1bb2d511a) is throwing 404. I don't think it is related to these changes but adding the point here anyway.**

### Unit Test output
No test failure is taking place with the changes.
![image](https://user-images.githubusercontent.com/40599381/71717201-15160680-2e39-11ea-8878-75e097a8df7e.png)
