### PR TITLE
[PROD-1440] -  Handling fragment DeprecationWarning

### DIFF
--- a/schoolyourself/schoolyourself.py
+++ b/schoolyourself/schoolyourself.py
@@ -9,7 +9,7 @@ from mako.template import Template
 
 from xblock.core import XBlock
 from xblock.fields import Scope, String
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 
 
 class SchoolYourselfXBlock(XBlock):


### PR DESCRIPTION
### [PROD-1440](https://openedx.atlassian.net/browse/PROD-1440)

Reducing logs to free up space in Splunk for a more meaningful history. Handling DeprecationWarning got `fragment`

`DeprecationWarning: xblock.fragment is deprecated. Please use web_fragments.fragment instead`