### PR TITLE
build: remove OpsGenie alert for Python upgrade failures

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -52,17 +52,4 @@ jobs:
           --target-branch="${{ env.target_branch }}" --base-branch-name="upgrade-python-requirements" \
           --commit-message="chore: Updating Python Requirements" --pr-title="Python Requirements Update" \
           --pr-body="Python requirements update.Please review the [changelogs](https://openedx.atlassian.net/wiki/spaces/TE/pages/1001521320/Python+Package+Changelogs) for the upgraded packages." \
-          --user-reviewers="" --team-reviewers="community-engineering" --delete-old-pull-requests
-
-      - name: Send failure notification
-        if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: email-smtp.us-east-1.amazonaws.com
-          server_port: 465
-          username: ${{secrets.EDX_SMTP_USERNAME}}
-          password: ${{secrets.EDX_SMTP_PASSWORD}}
-          subject: Upgrade python requirements workflow failed in ${{github.repository}}
-          to: community-engineering@edx.opsgenie.net
-          from: github-actions <github-actions@edx.org>
-          body: Upgrade python requirements workflow in ${{github.repository}} failed! For details see "github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          --user-reviewers="" --team-reviewers="" --delete-old-pull-requests


### PR DESCRIPTION
The Community Engineering team has agreed that we would only like to get tagged on Python upgrade notifications, not paged in Ops Genie. This PR removes OG notification and also removes the `team-reviewers` as that was not working; we are moving to being tagged in the `CODEOWNERS` file. See https://github.com/edx/schoolyourself-xblock/pull/13 

@kdmccormick @stvstnfrd before I go do this across all our XBlocks, could you check my syntax?