### PR TITLE
build: consolidate divergent forks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @edx/community-engineering

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -1,0 +1,55 @@
+name: Upgrade Requirements
+
+on:
+  schedule:
+    # will start the job at 00:30 UTC every Monday
+    - cron: "30 0 * * 1"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Target branch to create requirements PR against"
+        required: true
+        default: 'master'
+
+jobs:
+  upgrade_requirements:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        python-version: ["3.8"]
+
+    steps:
+      - name: setup target branch
+        run: echo "target_branch=$(if ['${{ github.event.inputs.branch }}' = '']; then echo 'master'; else echo '${{ github.event.inputs.branch }}'; fi)" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v1
+        with:
+          ref: ${{ env.target_branch }}
+      
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: make upgrade
+        run: |
+          cd $GITHUB_WORKSPACE
+          make upgrade
+
+      - name: setup testeng-ci
+        run: |
+          git clone https://github.com/edx/testeng-ci.git
+          cd $GITHUB_WORKSPACE/testeng-ci
+          pip install -r requirements/base.txt
+      - name: create pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
+          GITHUB_USER_EMAIL: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}
+        run: |  
+          cd $GITHUB_WORKSPACE/testeng-ci
+          python -m jenkins.pull_request_creator --repo-root=$GITHUB_WORKSPACE \
+          --target-branch="${{ env.target_branch }}" --base-branch-name="upgrade-python-requirements" \
+          --commit-message="chore: Updating Python Requirements" --pr-title="Python Requirements Update" \
+          --pr-body="Python requirements update.Please review the [changelogs](https://openedx.atlassian.net/wiki/spaces/TE/pages/1001521320/Python+Package+Changelogs) for the upgraded packages." \
+          --user-reviewers="" --team-reviewers="" --delete-old-pull-requests

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
+COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
+.PHONY: $(COMMON_CONSTRAINTS_TXT)
+$(COMMON_CONSTRAINTS_TXT):
+	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
+
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
-upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
+upgrade: $(COMMON_CONSTRAINTS_TXT)  ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -q -r requirements/pip_tools.txt
 	pip-compile --upgrade -o requirements/pip_tools.txt requirements/pip_tools.in
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,18 +4,36 @@
 #
 #    make upgrade
 #
-appdirs==1.4.4            # via fs
-fs==2.4.11                # via xblock
-lxml==4.6.2               # via xblock
-mako==1.1.3               # via -r requirements/base.in
-markupsafe==1.1.1         # via mako, xblock
-python-dateutil==2.8.1    # via xblock
-pytz==2020.5              # via fs, xblock
-pyyaml==5.3.1             # via xblock
-six==1.15.0               # via fs, python-dateutil, xblock
-web-fragments==0.3.2      # via xblock
-webob==1.8.6              # via xblock
-xblock==1.4.0             # via -r requirements/base.in
+appdirs==1.4.4
+    # via fs
+fs==2.4.13
+    # via xblock
+lxml==4.6.3
+    # via xblock
+mako==1.1.4
+    # via -r requirements/base.in
+markupsafe==2.0.1
+    # via
+    #   mako
+    #   xblock
+python-dateutil==2.8.1
+    # via xblock
+pytz==2021.1
+    # via
+    #   fs
+    #   xblock
+pyyaml==5.4.1
+    # via xblock
+six==1.16.0
+    # via
+    #   fs
+    #   python-dateutil
+web-fragments==1.0.0
+    # via xblock
+webob==1.8.7
+    # via xblock
+xblock==1.4.2
+    # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,0 +1,26 @@
+# A central location for most common version constraints
+# (across edx repos) for pip-installation.
+#
+# Similar to other constraint files this file doesn't install any packages.
+# It specifies version constraints that will be applied if a package is needed.
+# When pinning something here, please provide an explanation of why it is a good
+# idea to pin this package across all edx repos, Ideally, link to other information
+# that will help people in the future to remove the pin when possible.
+# Writing an issue against the offending project and linking to it here is good.
+#
+# Note: Changes to this file will automatically be used by other repos, referencing
+#  this file from Github directly. It does not require packaging in edx-lint.
+
+
+# using LTS django version
+Django<2.3
+
+# docutils version 0.17 is causing docs rendering to fail
+# See https://sourceforge.net/p/docutils/bugs/417/
+docutils==0.16
+
+# latest version is causing e2e failures in edx-platform.
+drf-jwt<1.19.1
+
+# Newer versions causing tests failures in multiple repos.
+pyjwt[crypto]==1.7.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,3 +7,6 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
+
+# Common constraints for edx repos
+-c common_constraints.txt

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,8 +4,14 @@
 #
 #    make upgrade
 #
-click==7.1.2              # via pip-tools
-pip-tools==5.5.0          # via -r requirements/pip_tools.in
+click==8.0.1
+    # via pip-tools
+pep517==0.10.0
+    # via pip-tools
+pip-tools==6.1.0
+    # via -r requirements/pip_tools.in
+toml==0.10.2
+    # via pep517
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,27 +4,71 @@
 #
 #    make upgrade
 #
-appdirs==1.4.4            # via -r requirements/base.txt, fs
-attrs==20.3.0             # via pytest
-fs==2.4.11                # via -r requirements/base.txt, xblock
-iniconfig==1.1.1          # via pytest
-lxml==4.6.2               # via -r requirements/base.txt, xblock
-mako==1.1.3               # via -r requirements/base.txt
-markupsafe==1.1.1         # via -r requirements/base.txt, mako, xblock
-mock==4.0.3               # via -r requirements/test.in
-packaging==20.8           # via pytest
-pluggy==0.13.1            # via pytest
-py==1.10.0                # via pytest
-pyparsing==2.4.7          # via packaging
-pytest==6.2.1             # via -r requirements/test.in
-python-dateutil==2.8.1    # via -r requirements/base.txt, xblock
-pytz==2020.5              # via -r requirements/base.txt, fs, xblock
-pyyaml==5.3.1             # via -r requirements/base.txt, xblock
-six==1.15.0               # via -r requirements/base.txt, fs, python-dateutil, xblock
-toml==0.10.2              # via pytest
-web-fragments==0.3.2      # via -r requirements/base.txt, xblock
-webob==1.8.6              # via -r requirements/base.txt, xblock
-xblock==1.4.0             # via -r requirements/base.txt
+appdirs==1.4.4
+    # via
+    #   -r requirements/base.txt
+    #   fs
+attrs==21.2.0
+    # via pytest
+fs==2.4.13
+    # via
+    #   -r requirements/base.txt
+    #   xblock
+iniconfig==1.1.1
+    # via pytest
+lxml==4.6.3
+    # via
+    #   -r requirements/base.txt
+    #   xblock
+mako==1.1.4
+    # via -r requirements/base.txt
+markupsafe==2.0.1
+    # via
+    #   -r requirements/base.txt
+    #   mako
+    #   xblock
+mock==4.0.3
+    # via -r requirements/test.in
+packaging==20.9
+    # via pytest
+pluggy==0.13.1
+    # via pytest
+py==1.10.0
+    # via pytest
+pyparsing==2.4.7
+    # via packaging
+pytest==6.2.4
+    # via -r requirements/test.in
+python-dateutil==2.8.1
+    # via
+    #   -r requirements/base.txt
+    #   xblock
+pytz==2021.1
+    # via
+    #   -r requirements/base.txt
+    #   fs
+    #   xblock
+pyyaml==5.4.1
+    # via
+    #   -r requirements/base.txt
+    #   xblock
+six==1.16.0
+    # via
+    #   -r requirements/base.txt
+    #   fs
+    #   python-dateutil
+toml==0.10.2
+    # via pytest
+web-fragments==1.0.0
+    # via
+    #   -r requirements/base.txt
+    #   xblock
+webob==1.8.7
+    # via
+    #   -r requirements/base.txt
+    #   xblock
+xblock==1.4.2
+    # via -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,14 +4,29 @@
 #
 #    make upgrade
 #
-appdirs==1.4.4            # via virtualenv
-distlib==0.3.1            # via virtualenv
-filelock==3.0.12          # via tox, virtualenv
-packaging==20.8           # via tox
-pluggy==0.13.1            # via tox
-py==1.10.0                # via tox
-pyparsing==2.4.7          # via packaging
-six==1.15.0               # via tox, virtualenv
-toml==0.10.2              # via tox
-tox==3.21.0               # via -r requirements/tox.in
-virtualenv==20.3.0        # via tox
+appdirs==1.4.4
+    # via virtualenv
+distlib==0.3.2
+    # via virtualenv
+filelock==3.0.12
+    # via
+    #   tox
+    #   virtualenv
+packaging==20.9
+    # via tox
+pluggy==0.13.1
+    # via tox
+py==1.10.0
+    # via tox
+pyparsing==2.4.7
+    # via packaging
+six==1.16.0
+    # via
+    #   tox
+    #   virtualenv
+toml==0.10.2
+    # via tox
+tox==3.23.1
+    # via -r requirements/tox.in
+virtualenv==20.4.7
+    # via tox

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,14 +4,47 @@
 #
 #    make upgrade
 #
-appdirs==1.4.4            # via -r requirements/tox.txt, virtualenv
-distlib==0.3.1            # via -r requirements/tox.txt, virtualenv
-filelock==3.0.12          # via -r requirements/tox.txt, tox, virtualenv
-packaging==20.8           # via -r requirements/tox.txt, tox
-pluggy==0.13.1            # via -r requirements/tox.txt, tox
-py==1.10.0                # via -r requirements/tox.txt, tox
-pyparsing==2.4.7          # via -r requirements/tox.txt, packaging
-six==1.15.0               # via -r requirements/tox.txt, tox, virtualenv
-toml==0.10.2              # via -r requirements/tox.txt, tox
-tox==3.21.0               # via -r requirements/tox.txt
-virtualenv==20.3.0        # via -r requirements/tox.txt, tox
+appdirs==1.4.4
+    # via
+    #   -r requirements/tox.txt
+    #   virtualenv
+distlib==0.3.2
+    # via
+    #   -r requirements/tox.txt
+    #   virtualenv
+filelock==3.0.12
+    # via
+    #   -r requirements/tox.txt
+    #   tox
+    #   virtualenv
+packaging==20.9
+    # via
+    #   -r requirements/tox.txt
+    #   tox
+pluggy==0.13.1
+    # via
+    #   -r requirements/tox.txt
+    #   tox
+py==1.10.0
+    # via
+    #   -r requirements/tox.txt
+    #   tox
+pyparsing==2.4.7
+    # via
+    #   -r requirements/tox.txt
+    #   packaging
+six==1.16.0
+    # via
+    #   -r requirements/tox.txt
+    #   tox
+    #   virtualenv
+toml==0.10.2
+    # via
+    #   -r requirements/tox.txt
+    #   tox
+tox==3.23.1
+    # via -r requirements/tox.txt
+virtualenv==20.4.7
+    # via
+    #   -r requirements/tox.txt
+    #   tox


### PR DESCRIPTION
Somewhere along the line, this repo's `HEAD` got pointed _away_ from `master` and _to_ `feanil/python-modernize` .

Since then, most (mostly human) PRs have merged to `HEAD`, `feanil/python-modernize`, while some PRs (mostly bots) have merged to `master`.

This can be explained by each flow's default behavior:
- the Github web UI defaults PRs to `HEAD`
- scripts are often (hard-)coded to assume `HEAD` is `master`.

This PR combines the two timelines, as well as again updating dependencies. After this merges, I intend to:
- fast-forward `feanil/python-modernize` to match the new `master`
- reset `HEAD` to `master`
- update our deploy scripts/requirements to ensure we are deploying from `master` (or derivative).